### PR TITLE
ci(release-please): v0.x の間は BREAKING でも MINOR bump に留める

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary

PR #19（feat!）が release-please で **v1.0.0**（MAJOR bump）の Release PR #20 を生成してしまった。Issue #1 の方針確定段階で「v0.x の間は BREAKING でも MINOR bump（v0.4.0）」を想定していたため、v0.x 中は MAJOR ジャンプを抑制する設定を追加する。

## 変更

`release-please-config.json` に 2 行追加:

- `"bump-minor-pre-major": true` — v0.x 中は `feat!` / `BREAKING CHANGE` でも MAJOR ではなく MINOR にする
- `"bump-patch-for-minor-pre-major": true` — v0.x 中は `feat` で MINOR ではなく PATCH にする（feat はもっと頻発するため）

## マージ後の段取り

1. このパッチ PR を admin bypass で squash merge（低リスク CI 設定変更、memory「安全な変更は admin bypass で素早く merge」に該当）
2. main への push で release-please workflow が再走
3. 既存 Release PR #20 が **v0.4.0 に更新される**（または closed → 新規 v0.4.0 PR が作成される）想定

Refs #1