### PR TITLE
docs(claude-md): release-please の bump 挙動表を pre-1.0 実態に合わせて修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,12 +24,21 @@ chore(plan): Phase 3.7 を追加
 
 このリポは [release-please](https://github.com/googleapis/release-please) で SemVer リリースを自動化しています。**コミットの `type` が直接リリース挙動を決める**ので、選択を慎重に。
 
-| type | 例 | release-please の挙動 |
+現在は **v0.x 系（pre-1.0）** で、`release-please-config.json` に以下 2 フラグが入っています:
+
+- `bump-minor-pre-major: true` — pre-1.0 では BREAKING を MAJOR ではなく **MINOR** に格下げ
+- `bump-patch-for-minor-pre-major: true` — pre-1.0 では `feat` を MINOR ではなく **PATCH** に格下げ
+
+その結果、pre-1.0 の bump は次のとおりです:
+
+| type | 例 | release-please の挙動（pre-1.0） |
 |---|---|---|
-| `feat` | 新プラグイン追加、subcommand 追加、UI 機能追加 | **MINOR bump（v0.X.0）** Release PR 生成 |
-| `fix` | プラグインの不具合修正 | **PATCH bump（v0.0.X）** Release PR 生成 |
-| `feat!` または body に `BREAKING CHANGE:` | 非互換な変更（subcommand 削除、引数仕様変更等） | **MAJOR bump（vX.0.0）** |
+| `feat` | 新プラグイン追加、subcommand 追加、UI 機能追加 | **PATCH bump（v0.X.Y → v0.X.Y+1）** Release PR 生成 |
+| `fix` | プラグインの不具合修正 | **PATCH bump** Release PR 生成 |
+| `feat!` または body に `BREAKING CHANGE:` | 非互換な変更（subcommand 削除、引数仕様変更等） | **MINOR bump（v0.X → v0.X+1.0）** Release PR 生成 |
 | `chore` / `docs` / `ci` / `refactor` / `style` / `test` / `build` | 内部整備、CI、ドキュメント、リファクタ | **何もしない**（Unreleased に蓄積） |
+
+v1.0 リリース後は上記フラグの効果が外れ、`feat` → MINOR / BREAKING → MAJOR に昇格する想定です。
 
 ### type 選択のチェックリスト
 


### PR DESCRIPTION
## Summary

- CLAUDE.md の bump 挙動表が `feat → MINOR` と書いていたが、`release-please-config.json` に `bump-patch-for-minor-pre-major: true` が入っているため pre-1.0 では実際は PATCH に格下げされる。表記と実態がズレていたので訂正
- pre-1.0 で効いている 2 フラグ（`bump-minor-pre-major` / `bump-patch-for-minor-pre-major`）を表の前で明示し、v1.0 後は昇格する旨も補足

## Background

直近のリリース履歴を見ると、`feat` 系 PR はすべて PATCH bump になっている:

| Release | 直前のコミット | 実際の bump |
|---|---|---|
| 0.4.0 | `feat!` PR #22（BREAKING） | MINOR |
| 0.4.1 | `feat` PR #24 | PATCH |
| 0.4.2 | `feat` PR #26 | PATCH |
| 0.4.3 | `feat` PR #32 | PATCH |

これは PR #21 で `bump-patch-for-minor-pre-major: true` が追加された結果だが、CLAUDE.md の表が当時のまま `MINOR` を指していたので、開発時に「これは MINOR bump だな」と誤って判断する原因になっていた。

## Test plan

- [x] `release-please-config.json` の 2 フラグの値を確認（両方 `true`）
- [x] 直近 4 リリースの bump レベルが `feat → PATCH` / `feat! → MINOR` の挙動と一致することを確認
- [x] 表内の文言と本文の補足文が論理的に整合していることを確認