### PR TITLE
feat(design-director): extract に sRGB hex 変換と多経路 CJK 検出を追加

### DIFF
--- a/plugins/design-director/skills/design-director/references/commands/extract.md
+++ b/plugins/design-director/skills/design-director/references/commands/extract.md
@@ -95,6 +95,10 @@ LLM 自身が書く。
      `surface` / `hairline` / `accent` 等の **canonical role に手動マッピ
      ング**。CSS custom properties に `--color-primary` 等があればそれを
      優先する
+   - **色 hex は各 entry の `srgb_hex` をそのまま採用する**（script が
+     `lab(...)` / `oklch(...)` 等をブラウザ経由で sRGB に正規化済み）。
+     LLM 側で LAB→sRGB を暗算しないこと。`custom_properties` に色値が
+     ある場合は対応する `custom_properties_srgb` の hex を使う
    - `typography`: observed の typography cluster を上位順に `display-xl`
      / `display-lg` / `heading-lg` / `body` / `caption` 等に割り当てる。
      viewport 内 + 大面積のクラスタを display 系に当てる

--- a/plugins/design-director/skills/design-director/scripts/extract-url.spec.ts
+++ b/plugins/design-director/skills/design-director/scripts/extract-url.spec.ts
@@ -5,13 +5,22 @@ import {
   clusterPxValues,
   clusterTypography,
   clusterValues,
+  computeIsCjk,
   formatObservedYaml,
   parseArgs,
   pickNearestExemplars,
+  rgbStringToHex,
   slugFromUrl,
   type RawElementObservation,
   type ObservedYaml,
+  type ResolvedColor,
 } from "./extract-url";
+
+const WHITE_BG: ResolvedColor = {
+  value: "rgb(255, 255, 255)",
+  srgb: "rgb(255, 255, 255)",
+  srgb_hex: "#ffffff",
+};
 
 describe("slugFromUrl", () => {
   it("hostname を dash 区切り小文字に変換する", () => {
@@ -49,6 +58,133 @@ describe("clusterValues", () => {
   });
 });
 
+describe("rgbStringToHex", () => {
+  it("rgb(r, g, b) を 6 桁 hex に変換", () => {
+    expect(rgbStringToHex("rgb(31, 31, 31)")).toBe("#1f1f1f");
+    expect(rgbStringToHex("rgb(0, 0, 0)")).toBe("#000000");
+    expect(rgbStringToHex("rgb(255, 255, 255)")).toBe("#ffffff");
+    expect(rgbStringToHex("rgb(0, 119, 199)")).toBe("#0077c7");
+  });
+
+  it("alpha=1 の rgba は 6 桁 hex に正規化する", () => {
+    expect(rgbStringToHex("rgba(31, 31, 31, 1)")).toBe("#1f1f1f");
+  });
+
+  it("alpha < 1 の rgba は 8 桁 hex で alpha を保持する", () => {
+    expect(rgbStringToHex("rgba(0, 0, 0, 0.5)")).toBe("#00000080");
+    expect(rgbStringToHex("rgba(0, 0, 0, 0)")).toBe("#00000000");
+  });
+
+  it("空白を含む入力も受理する", () => {
+    expect(rgbStringToHex("  rgb(  31 ,  31 ,  31  )  ")).toBe("#1f1f1f");
+  });
+
+  it("rgb / rgba 形式以外の値は null", () => {
+    expect(rgbStringToHex("transparent")).toBeNull();
+    expect(rgbStringToHex("lab(50 0 0)")).toBeNull();
+    expect(rgbStringToHex("oklch(0.7 0.1 200)")).toBeNull();
+    expect(rgbStringToHex("#fff")).toBeNull();
+    expect(rgbStringToHex("")).toBeNull();
+    expect(rgbStringToHex("not a color")).toBeNull();
+  });
+});
+
+describe("computeIsCjk", () => {
+  const baseInput = {
+    fontsResolved: [] as string[],
+    langAttr: "",
+    ogLocale: null as string | null,
+    hostname: "example.com",
+    fontChains: [] as string[],
+  };
+
+  it("全 signal が false なら is_cjk: false", () => {
+    const r = computeIsCjk(baseInput);
+    expect(r.is_cjk).toBe(false);
+    expect(r.is_cjk_signals).toEqual({
+      font_loaded: false,
+      lang_attr: false,
+      og_locale: null,
+      tld_jp: false,
+      font_chain_jp: false,
+    });
+  });
+
+  it("lang=ja のみで is_cjk: true", () => {
+    const r = computeIsCjk({ ...baseInput, langAttr: "ja" });
+    expect(r.is_cjk).toBe(true);
+    expect(r.is_cjk_signals.lang_attr).toBe(true);
+  });
+
+  it("lang=ja-JP / zh-Hans / ko-KR も拾う", () => {
+    expect(computeIsCjk({ ...baseInput, langAttr: "ja-JP" }).is_cjk_signals.lang_attr).toBe(true);
+    expect(computeIsCjk({ ...baseInput, langAttr: "zh-Hans" }).is_cjk_signals.lang_attr).toBe(true);
+    expect(computeIsCjk({ ...baseInput, langAttr: "ko-KR" }).is_cjk_signals.lang_attr).toBe(true);
+  });
+
+  it("lang=en は CJK 扱いしない", () => {
+    expect(computeIsCjk({ ...baseInput, langAttr: "en" }).is_cjk).toBe(false);
+    expect(computeIsCjk({ ...baseInput, langAttr: "en-US" }).is_cjk).toBe(false);
+  });
+
+  it("og_locale=ja_JP は値そのものを保持して is_cjk: true", () => {
+    const r = computeIsCjk({ ...baseInput, ogLocale: "ja_JP" });
+    expect(r.is_cjk).toBe(true);
+    expect(r.is_cjk_signals.og_locale).toBe("ja_JP");
+  });
+
+  it("og_locale=en_US は CJK 扱いせず og_locale は null", () => {
+    const r = computeIsCjk({ ...baseInput, ogLocale: "en_US" });
+    expect(r.is_cjk).toBe(false);
+    expect(r.is_cjk_signals.og_locale).toBeNull();
+  });
+
+  it("hostname が .jp で終われば tld_jp: true", () => {
+    expect(computeIsCjk({ ...baseInput, hostname: "example.jp" }).is_cjk_signals.tld_jp).toBe(true);
+    expect(computeIsCjk({ ...baseInput, hostname: "example.co.jp" }).is_cjk_signals.tld_jp).toBe(true);
+    expect(computeIsCjk({ ...baseInput, hostname: "example.com" }).is_cjk_signals.tld_jp).toBe(false);
+  });
+
+  it("font-family chain に CJK フォント名があれば font_chain_jp: true", () => {
+    const r = computeIsCjk({
+      ...baseInput,
+      fontChains: [
+        '-apple-system, "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif',
+      ],
+    });
+    expect(r.is_cjk).toBe(true);
+    expect(r.is_cjk_signals.font_chain_jp).toBe(true);
+  });
+
+  it("fonts_resolved に Noto Sans JP があれば font_loaded: true", () => {
+    const r = computeIsCjk({
+      ...baseInput,
+      fontsResolved: ["Inter", "Noto Sans JP"],
+    });
+    expect(r.is_cjk).toBe(true);
+    expect(r.is_cjk_signals.font_loaded).toBe(true);
+  });
+
+  it("system font だけの日本語サイト相当の入力でも tld+lang+chain で拾える", () => {
+    // .jp ドメイン + lang=ja + system font 経由の Noto Sans JP chain。
+    // fonts_resolved は空（Web font が無いため）
+    const r = computeIsCjk({
+      fontsResolved: [],
+      langAttr: "ja",
+      ogLocale: null,
+      hostname: "anonymized-product.example.jp",
+      fontChains: [
+        '-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans JP", "Hiragino Sans", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif',
+      ],
+    });
+    expect(r.is_cjk).toBe(true);
+    expect(r.is_cjk_signals.font_loaded).toBe(false);
+    expect(r.is_cjk_signals.lang_attr).toBe(true);
+    expect(r.is_cjk_signals.tld_jp).toBe(true);
+    expect(r.is_cjk_signals.font_chain_jp).toBe(true);
+  });
+});
+
 describe("clusterPxValues", () => {
   it('"NNpx" 文字列をクラスタリングして代表値を返す', () => {
     const out = clusterPxValues(["4px", "4px", "8px", "16px", "16.4px"], 0.05);
@@ -78,10 +214,14 @@ describe("bucketColorsByRole", () => {
     textTransform: "none",
     fontVariantNumeric: "normal",
     color: "rgb(0, 0, 0)",
+    colorSrgb: "rgb(0, 0, 0)",
     backgroundColor: "rgba(0, 0, 0, 0)",
+    backgroundColorSrgb: null,
     ancestorBackground: "rgb(255, 255, 255)",
+    ancestorBackgroundSrgb: "rgb(255, 255, 255)",
     borderRadius: "0px",
     borderTopColor: "rgba(0, 0, 0, 0)",
+    borderTopColorSrgb: null,
     borderTopWidth: "0px",
     paddingTop: "0px",
     paddingRight: "0px",
@@ -93,10 +233,16 @@ describe("bucketColorsByRole", () => {
 
   it("body 背景と同色背景上のテキストは text_on_canvas に入る", () => {
     const r = bucketColorsByRole(
-      [baseObs({ color: "rgb(34, 34, 34)", ancestorBackground: "rgb(255, 255, 255)" })],
-      "rgb(255, 255, 255)",
+      [baseObs({
+        color: "rgb(34, 34, 34)",
+        colorSrgb: "rgb(34, 34, 34)",
+        ancestorBackground: "rgb(255, 255, 255)",
+      })],
+      WHITE_BG,
     );
     expect(r.text_on_canvas[0].value).toBe("rgb(34, 34, 34)");
+    expect(r.text_on_canvas[0].srgb).toBe("rgb(34, 34, 34)");
+    expect(r.text_on_canvas[0].srgb_hex).toBe("#222222");
     expect(r.text_on_non_canvas).toEqual([]);
   });
 
@@ -106,19 +252,22 @@ describe("bucketColorsByRole", () => {
         baseObs({
           tag: "button",
           backgroundColor: "rgb(0, 119, 199)",
+          backgroundColorSrgb: "rgb(0, 119, 199)",
         }),
       ],
-      "rgb(255, 255, 255)",
+      WHITE_BG,
     );
     expect(r.button_backgrounds[0].value).toBe("rgb(0, 119, 199)");
+    expect(r.button_backgrounds[0].srgb_hex).toBe("#0077c7");
   });
 
   it("a タグの color は link_colors に入る（btn class が無い場合）", () => {
     const r = bucketColorsByRole(
-      [baseObs({ tag: "a", color: "rgb(0, 119, 199)" })],
-      "rgb(255, 255, 255)",
+      [baseObs({ tag: "a", color: "rgb(0, 119, 199)", colorSrgb: "rgb(0, 119, 199)" })],
+      WHITE_BG,
     );
     expect(r.link_colors[0].value).toBe("rgb(0, 119, 199)");
+    expect(r.link_colors[0].srgb_hex).toBe("#0077c7");
   });
 
   it("a.btn は button 扱いされ link_colors には入らない", () => {
@@ -128,10 +277,12 @@ describe("bucketColorsByRole", () => {
           tag: "a",
           classNames: ["btn"],
           color: "rgb(255, 255, 255)",
+          colorSrgb: "rgb(255, 255, 255)",
           backgroundColor: "rgb(0, 119, 199)",
+          backgroundColorSrgb: "rgb(0, 119, 199)",
         }),
       ],
-      "rgb(255, 255, 255)",
+      WHITE_BG,
     );
     expect(r.button_backgrounds[0].value).toBe("rgb(0, 119, 199)");
     expect(r.link_colors).toEqual([]);
@@ -140,10 +291,10 @@ describe("bucketColorsByRole", () => {
   it("transparent / rgba(...,0) は無視される", () => {
     const r = bucketColorsByRole(
       [
-        baseObs({ color: "transparent" }),
-        baseObs({ color: "rgba(0,0,0,0)" }),
+        baseObs({ color: "transparent", colorSrgb: null }),
+        baseObs({ color: "rgba(0,0,0,0)", colorSrgb: null }),
       ],
-      "rgb(255, 255, 255)",
+      WHITE_BG,
     );
     expect(r.text_on_canvas).toEqual([]);
   });
@@ -151,26 +302,53 @@ describe("bucketColorsByRole", () => {
   it("border 1〜3px のみが border_colors に入る", () => {
     const r = bucketColorsByRole(
       [
-        baseObs({ borderTopColor: "rgb(229, 229, 229)", borderTopWidth: "1px" }),
-        baseObs({ borderTopColor: "rgb(0, 0, 0)", borderTopWidth: "10px" }),
+        baseObs({
+          borderTopColor: "rgb(229, 229, 229)",
+          borderTopColorSrgb: "rgb(229, 229, 229)",
+          borderTopWidth: "1px",
+        }),
+        baseObs({
+          borderTopColor: "rgb(0, 0, 0)",
+          borderTopColorSrgb: "rgb(0, 0, 0)",
+          borderTopWidth: "10px",
+        }),
       ],
-      "rgb(255, 255, 255)",
+      WHITE_BG,
     );
     expect(r.border_colors).toHaveLength(1);
     expect(r.border_colors[0].value).toBe("rgb(229, 229, 229)");
+    expect(r.border_colors[0].srgb_hex).toBe("#e5e5e5");
   });
 
   it("頻度の降順でソートされる", () => {
     const r = bucketColorsByRole(
       [
-        baseObs({ color: "rgb(50, 50, 50)" }),
-        baseObs({ color: "rgb(100, 100, 100)" }),
-        baseObs({ color: "rgb(100, 100, 100)" }),
+        baseObs({ color: "rgb(50, 50, 50)", colorSrgb: "rgb(50, 50, 50)" }),
+        baseObs({ color: "rgb(100, 100, 100)", colorSrgb: "rgb(100, 100, 100)" }),
+        baseObs({ color: "rgb(100, 100, 100)", colorSrgb: "rgb(100, 100, 100)" }),
       ],
-      "rgb(255, 255, 255)",
+      WHITE_BG,
     );
     expect(r.text_on_canvas[0].value).toBe("rgb(100, 100, 100)");
     expect(r.text_on_canvas[0].count).toBe(2);
+  });
+
+  it("LAB 値を value で保ちつつ srgb_hex に sRGB hex を付与する", () => {
+    // ground truth: lab(8.36 0 0) ≈ #1f1f1f だが、bucketColorsByRole は
+    // page.evaluate 側で resolve 済みの srgb 文字列に依存する pure 関数なので
+    // ここでは srgb をそのまま渡したときに hex が伝播することだけ確認する
+    const r = bucketColorsByRole(
+      [
+        baseObs({
+          color: "lab(8.36 0 0)",
+          colorSrgb: "rgb(31, 31, 31)",
+          ancestorBackground: "rgb(255, 255, 255)",
+        }),
+      ],
+      WHITE_BG,
+    );
+    expect(r.text_on_canvas[0].value).toBe("lab(8.36 0 0)");
+    expect(r.text_on_canvas[0].srgb_hex).toBe("#1f1f1f");
   });
 });
 
@@ -191,10 +369,14 @@ describe("clusterTypography", () => {
     textTransform: "none",
     fontVariantNumeric: "normal",
     color: "rgb(0, 0, 0)",
+    colorSrgb: "rgb(0, 0, 0)",
     backgroundColor: "rgba(0,0,0,0)",
+    backgroundColorSrgb: null,
     ancestorBackground: "rgb(255, 255, 255)",
+    ancestorBackgroundSrgb: "rgb(255, 255, 255)",
     borderRadius: "0px",
     borderTopColor: "rgba(0,0,0,0)",
+    borderTopColorSrgb: null,
     borderTopWidth: "0px",
     paddingTop: "0px",
     paddingRight: "0px",
@@ -318,10 +500,21 @@ describe("formatObservedYaml", () => {
     extracted_at: "2026-04-28T00:00:00.000Z",
     viewport: "1280x800",
     custom_properties: { "--brand": "#ff0066" },
+    custom_properties_srgb: { "--brand": "#ff0066" },
     colors: {
-      bg_of_body: "rgb(255, 255, 255)",
+      bg_of_body: {
+        value: "rgb(255, 255, 255)",
+        srgb: "rgb(255, 255, 255)",
+        srgb_hex: "#ffffff",
+      },
       text_on_canvas: [
-        { value: "rgb(0, 0, 0)", count: 10, samples: ["p", "h1"] },
+        {
+          value: "rgb(0, 0, 0)",
+          srgb: "rgb(0, 0, 0)",
+          srgb_hex: "#000000",
+          count: 10,
+          samples: ["p", "h1"],
+        },
       ],
       text_on_non_canvas: [],
       button_backgrounds: [],
@@ -347,6 +540,14 @@ describe("formatObservedYaml", () => {
     radius_observed: [{ value: "0px", count: 5, semantic_hint: "none" }],
     spacing_observed: { paddings_clustered: ["0px", "16px"], gaps: ["8px"] },
     fonts_resolved: ["Inter"],
+    is_cjk: false,
+    is_cjk_signals: {
+      font_loaded: false,
+      lang_attr: false,
+      og_locale: null,
+      tld_jp: false,
+      font_chain_jp: false,
+    },
     exemplar_hints: ["editorial/linear.md"],
     warnings: ["test warning"],
   };
@@ -357,18 +558,27 @@ describe("formatObservedYaml", () => {
     expect(out).toContain("source: url");
     expect(out).toContain('viewport: 1280x800');
     expect(out).toContain('"--brand": "#ff0066"');
-    expect(out).toContain('bg_of_body: "rgb(255, 255, 255)"');
+    expect(out).toContain("custom_properties_srgb:");
+    expect(out).toContain("  bg_of_body:");
+    expect(out).toContain('    value: "rgb(255, 255, 255)"');
+    expect(out).toContain('    srgb_hex: "#ffffff"');
+    expect(out).toContain('      srgb_hex: "#000000"');
     expect(out).toContain('cluster_size: "64px"');
     expect(out).toContain('value: "0px", count: 5, semantic_hint: "none"');
     expect(out).toContain('paddings_clustered: ["0px", "16px"]');
-    expect(out).toContain('exemplar_hints:');
+    expect(out).toContain("is_cjk: false");
+    expect(out).toContain("is_cjk_signals:");
+    expect(out).toContain("  font_loaded: false");
+    expect(out).toContain("  og_locale: null");
+    expect(out).toContain("exemplar_hints:");
     expect(out).toContain('  - "editorial/linear.md"');
     expect(out).toContain('  - "test warning"');
   });
 
-  it("空配列は [] で出る", () => {
+  it("空配列は [] / 空オブジェクトは {} で出る", () => {
     const empty: ObservedYaml = {
       ...minimal,
+      custom_properties_srgb: {},
       typography: [],
       fonts_resolved: [],
       exemplar_hints: [],
@@ -378,6 +588,7 @@ describe("formatObservedYaml", () => {
     const out = formatObservedYaml(empty);
     expect(out).toContain("typography:\n  []");
     expect(out).toContain("fonts_resolved:\n  []");
+    expect(out).toContain("custom_properties_srgb:\n  {}");
   });
 
   it("ダブルクオートを正しくエスケープする", () => {
@@ -387,6 +598,36 @@ describe("formatObservedYaml", () => {
     };
     const out = formatObservedYaml(escaped);
     expect(out).toContain('"She said \\"hi\\""');
+  });
+
+  it("srgb / srgb_hex が null のときは null リテラルで出る", () => {
+    const withNulls: ObservedYaml = {
+      ...minimal,
+      colors: {
+        ...minimal.colors,
+        bg_of_body: { value: "transparent", srgb: null, srgb_hex: null },
+        text_on_canvas: [
+          {
+            value: "transparent",
+            srgb: null,
+            srgb_hex: null,
+            count: 1,
+            samples: ["p"],
+          },
+        ],
+      },
+      is_cjk: true,
+      is_cjk_signals: {
+        ...minimal.is_cjk_signals,
+        og_locale: "ja_JP",
+        lang_attr: true,
+      },
+    };
+    const out = formatObservedYaml(withNulls);
+    expect(out).toContain("    srgb: null");
+    expect(out).toContain("    srgb_hex: null");
+    expect(out).toContain('  og_locale: "ja_JP"');
+    expect(out).toContain("  lang_attr: true");
   });
 });
 

--- a/plugins/design-director/skills/design-director/scripts/extract-url.ts
+++ b/plugins/design-director/skills/design-director/scripts/extract-url.ts
@@ -38,8 +38,24 @@ export type ExtractOptions = {
 
 export type ColorEntry = {
   value: string;
+  srgb: string | null;
+  srgb_hex: string | null;
   count: number;
   samples: string[];
+};
+
+export type ResolvedColor = {
+  value: string;
+  srgb: string | null;
+  srgb_hex: string | null;
+};
+
+export type CjkSignals = {
+  font_loaded: boolean;
+  lang_attr: boolean;
+  og_locale: string | null;
+  tld_jp: boolean;
+  font_chain_jp: boolean;
 };
 
 export type RadiusEntry = {
@@ -79,10 +95,14 @@ export type RawElementObservation = {
   textTransform: string;
   fontVariantNumeric: string;
   color: string;
+  colorSrgb: string | null;
   backgroundColor: string;
+  backgroundColorSrgb: string | null;
   ancestorBackground: string;
+  ancestorBackgroundSrgb: string | null;
   borderRadius: string;
   borderTopColor: string;
+  borderTopColorSrgb: string | null;
   borderTopWidth: string;
   paddingTop: string;
   paddingRight: string;
@@ -92,7 +112,7 @@ export type RawElementObservation = {
 };
 
 export type BucketedColors = {
-  bg_of_body: string;
+  bg_of_body: ResolvedColor;
   text_on_canvas: ColorEntry[];
   text_on_non_canvas: ColorEntry[];
   button_backgrounds: ColorEntry[];
@@ -106,6 +126,7 @@ export type ObservedYaml = {
   extracted_at: string;
   viewport: string;
   custom_properties: Record<string, string>;
+  custom_properties_srgb: Record<string, string>;
   colors: BucketedColors;
   typography: TypographyCluster[];
   radius_observed: RadiusEntry[];
@@ -114,6 +135,8 @@ export type ObservedYaml = {
     gaps: string[];
   };
   fonts_resolved: string[];
+  is_cjk: boolean;
+  is_cjk_signals: CjkSignals;
   exemplar_hints: string[];
   warnings: string[];
 };
@@ -194,30 +217,86 @@ function roundTo(n: number, step: number): number {
 }
 
 /**
+ * "rgb(r, g, b)" / "rgba(r, g, b, a)" を sRGB hex 文字列に変換する。
+ * alpha が 1 のときは 6 桁、それ以外は 8 桁。受理できない入力は null。
+ */
+export function rgbStringToHex(s: string): string | null {
+  if (!s) return null;
+  const m = /^rgba?\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*(?:,\s*([\d.]+)\s*)?\)$/.exec(
+    s.trim(),
+  );
+  if (!m) return null;
+  const clamp255 = (n: number) => Math.max(0, Math.min(255, Math.round(n)));
+  const r = clamp255(parseFloat(m[1]));
+  const g = clamp255(parseFloat(m[2]));
+  const b = clamp255(parseFloat(m[3]));
+  const toHex = (n: number) => n.toString(16).padStart(2, "0");
+  const base = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+  if (m[4] === undefined) return base;
+  const a = parseFloat(m[4]);
+  if (!Number.isFinite(a)) return null;
+  const alpha = clamp255(a * 255);
+  if (alpha === 255) return base;
+  return base + toHex(alpha);
+}
+
+const CJK_FONT_REGEX =
+  /noto.*(cjk|jp|kr|sc|tc)|hiragino|yu[\s-]?gothic|meiryo|ms[\s-]?p?gothic|source han/i;
+
+/**
+ * CJK サイト判定。5 経路の signal を OR で合算し、判定根拠も返す。
+ *
+ * - font_loaded: document.fonts に CJK フォント family が含まれる
+ * - lang_attr: <html lang="ja|zh|ko"> （ja-JP / zh-Hans 等のサブタグも許容）
+ * - og_locale: <meta property="og:locale"> の値が CJK ロケールなら値そのものを保持
+ * - tld_jp: hostname が .jp で終わる
+ * - font_chain_jp: observed font-family chain や CP 値に CJK フォント名
+ */
+export function computeIsCjk(opts: {
+  fontsResolved: string[];
+  langAttr: string;
+  ogLocale: string | null;
+  hostname: string;
+  fontChains: string[];
+}): { is_cjk: boolean; is_cjk_signals: CjkSignals } {
+  const font_loaded = opts.fontsResolved.some((f) => CJK_FONT_REGEX.test(f ?? ""));
+  const lang_attr = /^(ja|zh|ko)(-|$)/i.test((opts.langAttr ?? "").trim());
+  const ogTrim = opts.ogLocale ? opts.ogLocale.trim() : "";
+  const og_locale = ogTrim && /^(ja|zh|ko)/i.test(ogTrim) ? ogTrim : null;
+  const tld_jp = /\.jp$/i.test(opts.hostname);
+  const font_chain_jp = opts.fontChains.some((f) => CJK_FONT_REGEX.test(f ?? ""));
+  const is_cjk = font_loaded || lang_attr || !!og_locale || tld_jp || font_chain_jp;
+  return {
+    is_cjk,
+    is_cjk_signals: { font_loaded, lang_attr, og_locale, tld_jp, font_chain_jp },
+  };
+}
+
+type ColorBucket = Map<string, { srgb: string | null; count: number; samples: Set<string> }>;
+
+/**
  * raw observation から色を role-context バケットに分類する。
  * whole-page frequency ではなく、要素の役割（canvas / button / link / border）で
  * 別バケットに入れる。
  */
 export function bucketColorsByRole(
   observations: RawElementObservation[],
-  bodyBg: string,
+  bodyBg: ResolvedColor,
 ): BucketedColors {
-  const textOnCanvas = new Map<string, { count: number; samples: Set<string> }>();
-  const textOnNonCanvas = new Map<string, { count: number; samples: Set<string> }>();
-  const buttonBg = new Map<string, { count: number; samples: Set<string> }>();
-  const linkColor = new Map<string, { count: number; samples: Set<string> }>();
-  const borderColor = new Map<string, { count: number; samples: Set<string> }>();
+  const textOnCanvas: ColorBucket = new Map();
+  const textOnNonCanvas: ColorBucket = new Map();
+  const buttonBg: ColorBucket = new Map();
+  const linkColor: ColorBucket = new Map();
+  const borderColor: ColorBucket = new Map();
 
-  const bump = (
-    map: Map<string, { count: number; samples: Set<string> }>,
-    key: string,
-    sample: string,
-  ) => {
-    if (!key || isTransparent(key)) return;
-    const cur = map.get(key) ?? { count: 0, samples: new Set<string>() };
+  const bump = (map: ColorBucket, value: string, srgb: string | null, sample: string) => {
+    if (!value || isTransparent(value)) return;
+    const cur = map.get(value) ?? { srgb, count: 0, samples: new Set<string>() };
     cur.count += 1;
     if (cur.samples.size < 5) cur.samples.add(sample);
-    map.set(key, cur);
+    // 同一 value で srgb が後から取れたら採用する（先勝ちで null なら更新）
+    if (cur.srgb === null && srgb !== null) cur.srgb = srgb;
+    map.set(value, cur);
   };
 
   for (const o of observations) {
@@ -228,23 +307,23 @@ export function bucketColorsByRole(
     const sample = describeSelector(o);
 
     if (isLikelyButton) {
-      bump(buttonBg, o.backgroundColor, sample);
+      bump(buttonBg, o.backgroundColor, o.backgroundColorSrgb, sample);
     }
     if (isLikelyLink) {
-      bump(linkColor, o.color, sample);
+      bump(linkColor, o.color, o.colorSrgb, sample);
     }
 
     // border (1〜3px のみを hairline 候補に)
     const bw = parsePx(o.borderTopWidth);
     if (bw !== null && bw >= 0.5 && bw <= 3) {
-      bump(borderColor, o.borderTopColor, sample);
+      bump(borderColor, o.borderTopColor, o.borderTopColorSrgb, sample);
     }
 
     // text bucket: canvas vs non-canvas
-    if (sameColor(o.ancestorBackground, bodyBg)) {
-      bump(textOnCanvas, o.color, sample);
+    if (sameColor(o.ancestorBackground, bodyBg.value)) {
+      bump(textOnCanvas, o.color, o.colorSrgb, sample);
     } else {
-      bump(textOnNonCanvas, o.color, sample);
+      bump(textOnNonCanvas, o.color, o.colorSrgb, sample);
     }
   }
 
@@ -258,12 +337,12 @@ export function bucketColorsByRole(
   };
 }
 
-function toColorEntries(
-  m: Map<string, { count: number; samples: Set<string> }>,
-): ColorEntry[] {
+function toColorEntries(m: ColorBucket): ColorEntry[] {
   return Array.from(m.entries())
-    .map(([value, { count, samples }]) => ({
+    .map(([value, { srgb, count, samples }]) => ({
       value,
+      srgb,
+      srgb_hex: srgb ? rgbStringToHex(srgb) : null,
       count,
       samples: Array.from(samples),
     }))
@@ -482,8 +561,20 @@ export function formatObservedYaml(data: ObservedYaml): string {
     }
   }
   push("");
+  push("custom_properties_srgb:");
+  const cpSrgbKeys = Object.keys(data.custom_properties_srgb).sort();
+  if (cpSrgbKeys.length === 0) push("  {}");
+  else {
+    for (const k of cpSrgbKeys) {
+      push(`  ${yamlKey(k)}: ${yamlString(data.custom_properties_srgb[k])}`);
+    }
+  }
+  push("");
   push("colors:");
-  push(`  bg_of_body: ${yamlString(data.colors.bg_of_body)}`);
+  push("  bg_of_body:");
+  push(`    value: ${yamlString(data.colors.bg_of_body.value)}`);
+  push(`    srgb: ${yamlNullableString(data.colors.bg_of_body.srgb)}`);
+  push(`    srgb_hex: ${yamlNullableString(data.colors.bg_of_body.srgb_hex)}`);
   emitColorList("text_on_canvas", data.colors.text_on_canvas, push);
   emitColorList("text_on_non_canvas", data.colors.text_on_non_canvas, push);
   emitColorList("button_backgrounds", data.colors.button_backgrounds, push);
@@ -524,6 +615,14 @@ export function formatObservedYaml(data: ObservedYaml): string {
   if (data.fonts_resolved.length === 0) push("  []");
   for (const f of data.fonts_resolved) push(`  - ${yamlString(f)}`);
   push("");
+  push(`is_cjk: ${data.is_cjk}`);
+  push("is_cjk_signals:");
+  push(`  font_loaded: ${data.is_cjk_signals.font_loaded}`);
+  push(`  lang_attr: ${data.is_cjk_signals.lang_attr}`);
+  push(`  og_locale: ${yamlNullableString(data.is_cjk_signals.og_locale)}`);
+  push(`  tld_jp: ${data.is_cjk_signals.tld_jp}`);
+  push(`  font_chain_jp: ${data.is_cjk_signals.font_chain_jp}`);
+  push("");
   push("exemplar_hints:");
   if (data.exemplar_hints.length === 0) push("  []");
   for (const e of data.exemplar_hints) push(`  - ${yamlString(e)}`);
@@ -542,9 +641,11 @@ function emitColorList(name: string, entries: ColorEntry[], push: (s: string) =>
   }
   push(`  ${name}:`);
   for (const e of entries) {
-    push(
-      `    - { value: ${yamlString(e.value)}, count: ${e.count}, samples: [${e.samples.map(yamlString).join(", ")}] }`,
-    );
+    push(`    - value: ${yamlString(e.value)}`);
+    push(`      srgb: ${yamlNullableString(e.srgb)}`);
+    push(`      srgb_hex: ${yamlNullableString(e.srgb_hex)}`);
+    push(`      count: ${e.count}`);
+    push(`      samples: [${e.samples.map(yamlString).join(", ")}]`);
   }
 }
 
@@ -553,6 +654,11 @@ function yamlString(s: string): string {
   if (s === "") return '""';
   // Always quote with double quotes and escape minimally.
   return '"' + String(s).replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+}
+
+function yamlNullableString(s: string | null | undefined): string {
+  if (s === null || s === undefined) return "null";
+  return yamlString(s);
 }
 
 function yamlKey(k: string): string {
@@ -687,7 +793,13 @@ export async function extractUrl(opts: ExtractOptions): Promise<ExtractResult> {
     await fs.writeFile(path.join(outputDir, "page.html"), html, "utf-8");
 
     // Stage F: aggregate to ObservedYaml
-    const bodyBg = evidence.bodyBackground ?? "rgb(255, 255, 255)";
+    const bodyBgRaw = evidence.bodyBackground?.value ?? "rgb(255, 255, 255)";
+    const bodyBgSrgb = evidence.bodyBackground?.srgb ?? null;
+    const bodyBg: ResolvedColor = {
+      value: bodyBgRaw,
+      srgb: bodyBgSrgb,
+      srgb_hex: bodyBgSrgb ? rgbStringToHex(bodyBgSrgb) : null,
+    };
     const colors = bucketColorsByRole(evidence.observations, bodyBg);
     const typography = clusterTypography(evidence.observations);
     const radius_observed = aggregateRadius(
@@ -702,20 +814,34 @@ export async function extractUrl(opts: ExtractOptions): Promise<ExtractResult> {
       0.10,
     );
 
-    const isCjk = evidence.fontsResolved.some((f) =>
-      /noto.*(cjk|jp|kr)|hiragino|yu[\s-]?gothic|meiryo|ms[\s-]?(p|)gothic|source han/i.test(f),
-    );
     const hostname = opts.url ? safeHostname(opts.url) : slug;
+    const fontChains = [
+      ...evidence.observations.map((o) => o.fontFamily),
+      ...Object.entries(evidence.customProperties)
+        .filter(([k]) => /font-?family/i.test(k))
+        .map(([, v]) => v),
+    ];
+    const { is_cjk, is_cjk_signals } = computeIsCjk({
+      fontsResolved: evidence.fontsResolved,
+      langAttr: evidence.langAttr,
+      ogLocale: evidence.ogLocale,
+      hostname,
+      fontChains,
+    });
     const exemplarFiles = await listFrontmatterDesignMdFiles().catch(() => [] as string[]);
     const exemplar_hints = pickNearestExemplars({
       hostname,
-      isCjk,
+      isCjk: is_cjk,
       availableFiles: exemplarFiles,
     });
 
-    if (!isCjk && /(\.jp$|note\.com|qiita\.com|zenn\.dev|smarthr|cookpad)/i.test(hostname)) {
+    if (
+      is_cjk &&
+      !is_cjk_signals.font_loaded &&
+      /(\.jp$|note\.com|qiita\.com|zenn\.dev|smarthr|cookpad)/i.test(hostname)
+    ) {
       warnings.push(
-        "日本語サイトと推測されますが Noto CJK 等の resolved フォントが検出できませんでした。`sudo apt install fonts-noto-cjk` を検討してください。",
+        "日本語サイトと判定しましたが Noto CJK 等の resolved フォントが検出できませんでした。`sudo apt install fonts-noto-cjk` を検討してください。",
       );
     }
 
@@ -725,11 +851,14 @@ export async function extractUrl(opts: ExtractOptions): Promise<ExtractResult> {
       extracted_at: new Date().toISOString(),
       viewport: `${viewport.width}x${viewport.height}`,
       custom_properties: evidence.customProperties,
+      custom_properties_srgb: evidence.customPropertiesSrgb,
       colors,
       typography,
       radius_observed,
       spacing_observed: { paddings_clustered, gaps },
       fonts_resolved: evidence.fontsResolved,
+      is_cjk,
+      is_cjk_signals,
       exemplar_hints,
       warnings,
     };
@@ -790,8 +919,11 @@ async function listFrontmatterDesignMdFiles(): Promise<string[]> {
 type PageEvidence = {
   observations: RawElementObservation[];
   customProperties: Record<string, string>;
+  customPropertiesSrgb: Record<string, string>;
   fontsResolved: string[];
-  bodyBackground: string;
+  bodyBackground: { value: string; srgb: string | null };
+  langAttr: string;
+  ogLocale: string | null;
 };
 
 async function collectEvidence(
@@ -800,39 +932,44 @@ async function collectEvidence(
 ): Promise<PageEvidence> {
   return await page.evaluate(
     ({ targetSelectors, viewportH }) => {
-      type Obs = {
-        selector: string;
-        tag: string;
-        classNames: string[];
-        rect: { width: number; height: number; x: number; y: number };
-        inFirstViewport: boolean;
-        fontFamily: string;
-        fontSize: string;
-        fontWeight: string;
-        lineHeight: string;
-        letterSpacing: string;
-        fontFeatureSettings: string;
-        fontVariationSettings: string;
-        textTransform: string;
-        fontVariantNumeric: string;
-        color: string;
-        backgroundColor: string;
-        ancestorBackground: string;
-        borderRadius: string;
-        borderTopColor: string;
-        borderTopWidth: string;
-        paddingTop: string;
-        paddingRight: string;
-        paddingBottom: string;
-        paddingLeft: string;
-        gap: string;
-      };
       const isTransparent = (c: string) => {
         if (!c) return true;
         const s = c.replace(/\s+/g, "").toLowerCase();
         if (s === "transparent") return true;
         return /^rgba\([^)]*?,0(\.0+)?\)$/.test(s);
       };
+
+      // sRGB resolver: 1x1 canvas に CSS color を塗って getImageData で
+      // gamut-mapped rgba を読む。これでブラウザに lab/oklch/oklab/color() 等の
+      // CSS Color Module 4 値を sRGB 整数に変換させる。
+      const probeCanvas = document.createElement("canvas");
+      probeCanvas.width = 1;
+      probeCanvas.height = 1;
+      const probeCtx = probeCanvas.getContext("2d", { willReadFrequently: true });
+      const toSrgb = (color: string): string | null => {
+        if (!probeCtx) return null;
+        if (!color) return null;
+        const c = color.trim();
+        if (c === "" || c === "transparent") return null;
+        if (typeof CSS === "undefined" || !CSS.supports("color", c)) return null;
+        try {
+          probeCtx.clearRect(0, 0, 1, 1);
+          // 透明初期化のあと不正値で fillStyle が拒否されても
+          // CSS.supports 側で弾いているので probeCtx は信頼できる
+          probeCtx.fillStyle = "rgba(0, 0, 0, 0)";
+          probeCtx.fillStyle = c;
+          probeCtx.fillRect(0, 0, 1, 1);
+          const data = probeCtx.getImageData(0, 0, 1, 1).data;
+          const r = data[0], g = data[1], b = data[2], a = data[3];
+          if (a === 0) return null;
+          if (a === 255) return `rgb(${r}, ${g}, ${b})`;
+          const alpha = Math.round((a / 255) * 1000) / 1000;
+          return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+        } catch {
+          return null;
+        }
+      };
+
       const resolveBg = (el: Element | null): string => {
         let cur: Element | null = el;
         while (cur) {
@@ -844,19 +981,25 @@ async function collectEvidence(
         return getComputedStyle(document.body).backgroundColor;
       };
 
-      // :root custom properties
+      // :root custom properties (raw + sRGB-resolved for color-like values)
       const customProperties: Record<string, string> = {};
+      const customPropertiesSrgb: Record<string, string> = {};
       const rootStyle = getComputedStyle(document.documentElement);
       for (let i = 0; i < rootStyle.length; i++) {
         const name = rootStyle[i];
         if (name && name.startsWith("--")) {
           const v = rootStyle.getPropertyValue(name).trim();
-          if (v) customProperties[name] = v;
+          if (!v) continue;
+          customProperties[name] = v;
+          if (typeof CSS !== "undefined" && CSS.supports("color", v)) {
+            const srgb = toSrgb(v);
+            if (srgb !== null) customPropertiesSrgb[name] = srgb;
+          }
         }
       }
 
       const seen = new Set<Element>();
-      const obs: Obs[] = [];
+      const obs: any[] = [];
       for (const sel of targetSelectors as string[]) {
         let nodes: Element[];
         try {
@@ -878,6 +1021,10 @@ async function collectEvidence(
             .split(/\s+/)
             .filter(Boolean)
             .slice(0, 3);
+          const color = cs.getPropertyValue("color");
+          const backgroundColor = cs.getPropertyValue("background-color");
+          const ancestorBackground = resolveBg(el.parentElement ?? el);
+          const borderTopColor = cs.getPropertyValue("border-top-color");
           obs.push({
             selector: tag + (classNames[0] ? `.${classNames[0]}` : ""),
             tag,
@@ -898,11 +1045,15 @@ async function collectEvidence(
             fontVariationSettings: cs.getPropertyValue("font-variation-settings"),
             textTransform: cs.getPropertyValue("text-transform"),
             fontVariantNumeric: cs.getPropertyValue("font-variant-numeric"),
-            color: cs.getPropertyValue("color"),
-            backgroundColor: cs.getPropertyValue("background-color"),
-            ancestorBackground: resolveBg(el.parentElement ?? el),
+            color,
+            colorSrgb: toSrgb(color),
+            backgroundColor,
+            backgroundColorSrgb: toSrgb(backgroundColor),
+            ancestorBackground,
+            ancestorBackgroundSrgb: toSrgb(ancestorBackground),
             borderRadius: cs.getPropertyValue("border-radius"),
-            borderTopColor: cs.getPropertyValue("border-top-color"),
+            borderTopColor,
+            borderTopColorSrgb: toSrgb(borderTopColor),
             borderTopWidth: cs.getPropertyValue("border-top-width"),
             paddingTop: cs.getPropertyValue("padding-top"),
             paddingRight: cs.getPropertyValue("padding-right"),
@@ -914,15 +1065,23 @@ async function collectEvidence(
       }
 
       const bodyBg = resolveBg(document.body);
+      const bodyBgSrgb = toSrgb(bodyBg);
       const fontsResolved = Array.from(
         new Set(Array.from((document as any).fonts ?? []).map((f: any) => f.family)),
       ) as string[];
 
+      const langAttr = (document.documentElement.getAttribute("lang") ?? "").trim();
+      const ogMeta = document.querySelector('meta[property="og:locale"]');
+      const ogLocale = ogMeta?.getAttribute("content")?.trim() || null;
+
       return {
         observations: obs as unknown as RawElementObservation[],
         customProperties,
+        customPropertiesSrgb,
         fontsResolved,
-        bodyBackground: bodyBg,
+        bodyBackground: { value: bodyBg, srgb: bodyBgSrgb },
+        langAttr,
+        ogLocale,
       };
     },
     { targetSelectors: TARGET_SELECTORS, viewportH: viewport.height },


### PR DESCRIPTION
## Summary

Issue #34 対応。Stage 1（script）で `lab(...)` / `oklch(...)` を canvas 経由で sRGB に正規化し、CJK 判定を 5 経路 OR に拡張する。

### A. LAB / OKLCH → sRGB 変換

- `page.evaluate()` 内に 1x1 canvas を 1 個用意し、`fillStyle` に CSS color 文字列を入れて `fillRect` → `getImageData` で sRGB 整数 (Uint8ClampedArray) を取り出す経路を導入
- `CSS.supports('color', value)` で事前バリデートし、無効値や `transparent` は `null`
- 全 observation の `color` / `backgroundColor` / `ancestorBackground` / `borderTopColor` を sRGB に解決
- `:root` の CSS custom properties を走査し、`CSS.supports('color', v)` で色値と認識されたものだけ `custom_properties_srgb` に登録（font-size 等は除外）
- `rgbStringToHex()` pure helper で `rgb(r,g,b)` → `#rrggbb` / `rgba(r,g,b,a<1)` → `#rrggbbaa` に変換
- スキーマ変更:
  - `ColorEntry` に `srgb: string | null` / `srgb_hex: string | null`
  - `bg_of_body` を `string` → `{ value, srgb, srgb_hex }`
  - 新規 `custom_properties_srgb: Record<string, string>`

### B. CJK 検出の多経路化

- `document.fonts` のみだった判定を 5 経路 OR に拡張:
  - `font_loaded`: 既存 経路
  - `lang_attr`: `<html lang>` を `/^(ja|zh|ko)(-|$)/i` で判定
  - `og_locale`: `<meta property="og:locale">` の値（`ja_JP` 等）
  - `tld_jp`: hostname が `.jp` で終わる
  - `font_chain_jp`: observation の font-family chain と `--*font-family*` CP に CJK フォント名
- `is_cjk: boolean` と判定根拠の `is_cjk_signals` を `DESIGN.observed.yaml` に追加し、`pickNearestExemplars` には合算後の bool を渡す

### C. Stage 2 ドキュメント

`references/commands/extract.md` に「色 hex は `srgb_hex` をそのまま採用し、LAB→sRGB を暗算しない」旨を明記。`custom_properties_srgb` の使い方も追記。

## Why

実運用で抽出してみたところ、Tailwind v4 + shadcn/ui 系の design system を持つサイトで `DESIGN.observed.yaml` が `lab(...)` 文字列のまま出てしまい、Stage 2 で LLM が暗算で `#hex` を作ると色相 12°ズレ・明度過小 などが系統的に発生する。原因はブラウザに任せれば 1 行で済む変換を LLM に押し付けていたこと。CJK 判定も Web font に依存しすぎて system font だけのサイトを取りこぼしており、exemplar に英語 design-md が並ぶ問題があった。両方とも `page.evaluate` の evidence 収集箇所の改修なので 1 PR にまとめている。

## Test plan

- [x] `bun run test` で 56 件すべて green（既存 39 + 新規 17）
- [x] 新規ユニットテスト:
  - `rgbStringToHex`: rgb/rgba/空白/不正値の網羅
  - `computeIsCjk`: 全 false / 単独 signal / system font 相当の組み合わせ
  - `bucketColorsByRole`: LAB 入力でも `srgb_hex` が伝播することを確認
  - `formatObservedYaml`: 新スキーマの YAML 出力 + null リテラル
- [x] ローカル `--from-html` で minimal な lab/oklch fixture HTML を抽出 → canvas 経由で `lab(98.84 0 0) → #fcfcfc` / `oklch(0.7 0.15 200) → #00b9c3` 等が出ることを確認
- [x] 日本語サイトの実 HTML（system font 主体）で `is_cjk: true`（`lang_attr` + `og_locale` でヒット）、exemplar_hints が `japanese-consumer/*` を選ぶことを確認

## release-please

`feat:` だが pre-1.0 の `bump-patch-for-minor-pre-major: true` 設定により **PATCH bump (0.4.3 → 0.4.4)**。